### PR TITLE
Feat/mysql charset

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Synopsis
         cluster = {
             {
                 servers = {
-                    {host="127.0.0.1", port=4444, weight=10, max_fails=3, fail_timeout=10},
+                    { host = "127.0.0.1", port = 4444, weight=10, max_fails=3, fail_timeout=10 },
                 }
             },
         },
@@ -97,11 +97,11 @@ Synopsis
         listen 12351;
         return 200 12351;
     }
-    
+
     init_by_lua_block {
-    	local config = require "config"
-    	local checkups = require "resty.checkups.api"
-    	checkups.init(config)
+        local config = require "config"
+        local checkups = require "resty.checkups.api"
+        checkups.init(config)
     }
 
     init_worker_by_lua_block {
@@ -125,7 +125,7 @@ Synopsis
                 local checkups = require "resty.checkups.api"
 
                 local callback = function(host, port)
-                local res = ngx.location.capture("/" .. port)
+                    local res = ngx.location.capture("/" .. port)
                     ngx.say(res.body)
                     return 1
                 end
@@ -140,7 +140,7 @@ Synopsis
                 ok, err = checkups.update_upstream("ups1", {
                     {
                         servers = {
-                            {host="127.0.0.1", port=12350, weight=10, max_fails=3, fail_timeout=10},
+                            { host = "127.0.0.1", port = 12350, weight=10, max_fails=3, fail_timeout=10 },
                         }
                     },
                 })
@@ -156,7 +156,7 @@ Synopsis
                 ok, err = checkups.update_upstream("ups2", {
                         {
                             servers = {
-                                {host="127.0.0.1", port=12351},
+                                { host="127.0.0.1", port=12351 },
                             }
                         },
                     })
@@ -169,8 +169,8 @@ Synopsis
                 ok, err = checkups.update_upstream("ups2", {
                         {
                             servers = {
-                                {host="127.0.0.1", port=12350, weight=10, max_fails=3, fail_timeout=10},
-                                {host="127.0.0.1", port=12351, weight=10, max_fails=3, fail_timeout=10},
+                                { host = "127.0.0.1", port = 12350, weight=10, max_fails=3, fail_timeout=10 },
+                                { host = "127.0.0.1", port = 12351, weight=10, max_fails=3, fail_timeout=10 },
                             }
                         },
                     })
@@ -312,29 +312,29 @@ Cluster configurations
 * `skey`: `_M.xxxxx`. `xxxxx` is the `skey`(service key) of this Cluster.
 * `enable`: Enable or disable heartbeats to servers. Default is `true`.
 * `typ`: Cluster type, must be one of `general`, `redis`, `mysql`, `http`. Default is `general`.
-	* `general`: Heartbeat by TCP `sock:connect`.
-	* `redis`: Heartbeat by redis `PING`. [lua-resty-redis](https://github.com/openresty/lua-resty-redis) module is required.
-	* `mysql`: Heartbeat by mysql `db:connect`. [lua-resty-mysql](https://github.com/openresty/lua-resty-mysql) module is required.
-	* `http`: Heartbeat by HTTP request. You can setup customized HTTP request and response codes in `http_opts`.
+    * `general`: Heartbeat by TCP `sock:connect`.
+    * `redis`: Heartbeat by redis `PING`. [lua-resty-redis](https://github.com/openresty/lua-resty-redis) module is required.
+    * `mysql`: Heartbeat by mysql `db:connect`. [lua-resty-mysql](https://github.com/openresty/lua-resty-mysql) module is required.
+    * `http`: Heartbeat by HTTP request. You can setup customized HTTP request and response codes in `http_opts`.
 * `timeout`: Connect timeout to upstream servers. Default is `5`.
 * `read_timeout`: Read timeout to upstream servers. Default is equal to `timeout`.
 * `send_timeout`: Write timeout to upstream servers. Default is equal to `timeout`.
 * `http_opts`: HTTP heartbeat configurations. Only works for `typ="http"`.
-	* `query`: HTTP request to heartbeat.
-	* `statuses`: If the code returned by server is set to `false`, then the server is considered to be failing.
+    * `query`: HTTP request to heartbeat.
+    * `statuses`: If the code returned by server is set to `false`, then the server is considered to be failing.
 
 * `mode`: Balance mode. Can be set to `hash`, `url_hash` or `ip_hash`. Checkups will balance servers by `hash_key`, `ngx.var.uri` or `ngx.var.remote_addr`. Default is `wrr`.
 * `protected`: If set to `true` and all the servers in the cluster are failing, checkups will not mark the last failing server as unavailable(`err`), instead, it will be marked as `unstable`(still available in next try). Default is `true`.
 * `cluster`: You can configure multiple levels according to the cluster priority, at each level you can configure a cluster of `servers`. Checkups will try next level only when all the servers in the prior level are consitered unavailable.
 
-	Instead of trying clusters by levels, you can configure checkups trying clusters by key(see `api` cluster above). Remember you should also pass extra argument like `opts.cluster_key={"dc1", "dc2"}` or `opts.cluster_key={3, 1, 2}` to [checkups.read_ok](#ready_ok) to make checkups trying on the order of `dc1`, `dc2` or `level 3`, `level 1`, `level 2`. If you haven't passed `opts.cluster_key` to [checkups.ready_ok](#ready_ok), checkups will still try clusters by levels. As for the above `api` cluster, checkups will eventually return `no servers available`.
+    Instead of trying clusters by levels, you can configure checkups trying clusters by key(see `api` cluster above). Remember you should also pass extra argument like `opts.cluster_key={"dc1", "dc2"}` or `opts.cluster_key={3, 1, 2}` to [checkups.read_ok](#ready_ok) to make checkups trying on the order of `dc1`, `dc2` or `level 3`, `level 1`, `level 2`. If you haven't passed `opts.cluster_key` to [checkups.ready_ok](#ready_ok), checkups will still try clusters by levels. As for the above `api` cluster, checkups will eventually return `no servers available`.
     * `try`: Retry count. Default is the number of servers.
     * `try_timeout`: Limits the time during which a request can be responsed, likewise nginx `proxy_next_upstream_timeout`.
     * `servers`: Configuration for `servers` are listed as follows,
-    	* `weight`: Sets the weight of the server. Default is `1`.
-    	* `max_fails`: Sets the number of unsuccessful attempts to communicate with the server that should happen in the duration set by the `fail_timeout` parameter. By default, the number of unsuccessful attempts is set to `0`, which disables the accounting of attempts. What is considered an unsuccessful attempt is defined by `http_opts.statuses` if `typ="http"` or a `nil`/`false` return by [checkups.ready_ok](#ready_ok). This options is only available in round-robin.
-    	* `fail_timeout`: Sets the time during which the specified number of unsuccessful attempts to communicate with the server should happen to consider the server unavailable and the period of time the server will be considered unavailable. By default, the parameter is set to `10` seconds. This options is only available in round-robin.
-    
+        * `weight`: Sets the weight of the server. Default is `1`.
+        * `max_fails`: Sets the number of unsuccessful attempts to communicate with the server that should happen in the duration set by the `fail_timeout` parameter. By default, the number of unsuccessful attempts is set to `0`, which disables the accounting of attempts. What is considered an unsuccessful attempt is defined by `http_opts.statuses` if `typ="http"` or a `nil`/`false` returned by [checkups.ready_ok](#ready_ok). This options is only available in round-robin.
+        * `fail_timeout`: Sets the time during which the specified number of unsuccessful attempts to communicate with the server should happen to consider the server unavailable and the period of time the server will be considered unavailable. By default, the parameter is set to `10` seconds. This options is only available in round-robin.
+
     * `upstream`: Name of Nginx upstream blocks. Checkups will extract servers from Nginx conf's upstream blocks in [prepare_checker](#prepare_checker). [lua-upstream-nginx-module](https://github.com/openresty/lua-upstream-nginx-module) module is required.
     * `upstream_only_backup`: If set to `true`, checkups will only extract backup servers from Nginx upstream blocks.
 
@@ -381,7 +381,7 @@ prepare_checker
 
 **phase:** *init_worker_by_lua*
 
-Copy configurations from `config.lua` to worker checkups, extract servers from Nginx upstream blocks and do some basic initialization. 
+Copy configurations from `config.lua` to worker checkups, extract servers from Nginx upstream blocks and do some basic initialization.
 
 
 create_checker

--- a/lib/resty/checkups/heartbeat.lua
+++ b/lib/resty/checkups/heartbeat.lua
@@ -256,6 +256,7 @@ local heartbeat = {
             database = ups.name,
             user = ups.user,
             password = ups.pass,
+            charset = ups.charset,
             max_packet_size = 1024*1024
         }
 


### PR DESCRIPTION
有些中间件在处理 mysql:connect 的时候需要验证 Client 的 charset 是否是合法的，例如 [TiDB L183-L403](https://github.com/pingcap/tidb/blob/master/util/charset/charset.go#L183-L403)
而 lua-resty-mysql 默认的 charset 为 0，和 mysql 协议是“不匹配的”，因此一直报连接错误。

顺便改了下文档 🐜 